### PR TITLE
fix T=ref.pose * T_curr_to_prev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,12 @@ set (CMAKE_CXX_FLAGS "-DPCL_ONLY_CORE_POINT_TYPES=ON -DNO_EXPLICIT_INSTANTIATION
 # Eigen
 include_directories( "/usr/include/eigen3" )
 # OpenCV
-find_package( OpenCV 3.4 REQUIRED )
+find_package( OpenCV REQUIRED HINTS "/home/bongb/opencv-4.0.0/build")
 include_directories( ${OpenCV_INCLUDE_DIRS} )
 # Sophus 
-find_package( Sophus REQUIRED )
+find_package( Sophus REQUIRED HINTS "/usr/local/")
 include_directories( ${Sophus_INCLUDE_DIRS} )
+
 # G2O
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules )
 find_package( G2O REQUIRED )
@@ -40,12 +41,13 @@ find_package( PCL REQUIRED )
 include_directories( ${PCL_INCLUDE_DIRS} )
 add_definitions( ${PCL_DEFINITIONS} )
 
+
 # Combine the above libraries
 set( THIRD_PARTY_LIBS 
     ${OpenCV_LIBS}
     ${PCL_LIBRARIES}
-    ${Sophus_LIBRARIES} # If "make install" is good, use this line
-    libSophus.so # If "make install" failed, copy files manully to usr/lib and usr/include, and use this line
+    #${Sophus_LIBRARIES} # If "make install" is good, use this line
+    /usr/local/lib/libSophus.so # If "make install" failed, copy files manully to usr/lib and usr/include, and use this line
     g2o_core g2o_stuff g2o_types_sba g2o_csparse_extension
     ${CSPARSE_LIBRARY}
 )

--- a/src/vo/vo.cpp
+++ b/src/vo/vo.cpp
@@ -86,7 +86,7 @@ void VisualOdometry::estimateMotionAnd3DPoints_()
     // -- Output
 
     // compute camera pose
-    T = ref_->T_w_c_ * basics::convertRt2T(R_curr_to_prev, t_curr_to_prev).inv();
+    T = ref_->T_w_c_ * basics::convertRt2T(R_curr_to_prev, t_curr_to_prev);
 
     // Get points that are used for triangulating new map points
     retainGoodTriangulationResult_();


### PR DESCRIPTION
In the estimateMotionAnd3D(), based on your original code T = ref_T_w_c_ * (Translation matrix)
However it resulted in wrong odometry. I changed it to multiply with the Translation matrix only, which makes it correct. Do you mind checking why it is like that. I think your logic is correct since to get the coordinate translation of camera 1 to camera 2 we would need to take the inverse, but that result in incorrect odometry for the example you provided.